### PR TITLE
Remove dependency of functions maven plugin for java templates

### DIFF
--- a/src/commands/createFunction/javaSteps/IJavaFunctionWizardContext.ts
+++ b/src/commands/createFunction/javaSteps/IJavaFunctionWizardContext.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IFunctionTemplate } from '../../../templates/IFunctionTemplate';
+import { IFunctionWizardContext } from '../IFunctionWizardContext';
+
+export interface IJavaFunctionWizardContext extends IFunctionWizardContext {
+    functionTemplate?: IJavaFunctionTemplate;
+}
+
+export interface IJavaFunctionTemplate extends IFunctionTemplate {
+    templateFiles: { [filename: string]: string };
+}

--- a/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
+++ b/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
@@ -40,6 +40,7 @@ export class JavaFunctionCreateStep extends FunctionCreateStepBase<IFunctionWiza
         args.set("className", functionName.replace('-', '_'));
         const content: string = substituteParametersInTemplate(template, args);
         const path: string = getJavaFunctionFilePath(context.projectPath, packageName, functionName);
+        await fse.ensureFile(path)
         await fse.writeFile(path, content)
         return getJavaFunctionFilePath(context.projectPath, packageName, functionName);
     }

--- a/src/templates/java/JavaTemplateProvider.ts
+++ b/src/templates/java/JavaTemplateProvider.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fse from 'fs-extra';
+import { HttpOperationResponse } from '@azure/ms-rest-js';
 import * as path from 'path';
 import { IActionContext } from 'vscode-azureextensionui';
-import { pomXmlFileName } from '../../constants';
 import { localize } from '../../localize';
-import { mavenUtils } from '../../utils/mavenUtils';
-import { parseJson } from '../../utils/parseJson';
+import { feedUtils } from '../../utils/feedUtils';
+import { nonNullProp } from '../../utils/nonNull';
+import { requestUtils } from '../../utils/requestUtils';
 import { ITemplates } from '../ITemplates';
 import { parseScriptTemplates } from '../script/parseScriptTemplates';
 import { ScriptTemplateProvider } from '../script/ScriptTemplateProvider';
@@ -22,42 +22,41 @@ interface IRawJavaTemplates {
     templates: object[];
 }
 
-/**
- * Java templates largely follow the same formatting as script templates, but they come from maven
- */
+const repositoryUrl: string = "https://repo1.maven.org/maven2/com/microsoft/azure/azure-functions-maven-plugin/maven-metadata.xml";
+const templatesUrl: string = "https://aka.ms/java-function-templates";
+const bindingsUrl: string = "https://aka.ms/java-function-templates-bindings";
+const resourcesUrl: string = "https://aka.ms/java-function-templates-resources";
+
 export class JavaTemplateProvider extends ScriptTemplateProvider {
+
+    private static latestVersion: string | null;
+
     public templateType: TemplateType = TemplateType.Java;
 
     protected get backupSubpath(): string {
         return path.join('java', this.version);
     }
 
-    public async getLatestTemplateVersion(): Promise<string> {
-        const pomPath: string = path.join(this.getProjectPath(), pomXmlFileName);
-        const pomContents: string = (await fse.readFile(pomPath)).toString();
-        const match: RegExpMatchArray | null = pomContents.match(/<azure.functions.maven.plugin.version>(.*)<\/azure.functions.maven.plugin.version>/i);
-        if (!match) {
-            throw new Error(localize('failedToDetectPluginVersion', 'Failed to detect Azure Functions maven plugin version.'));
-        } else {
-            return match[1].trim();
+    // todo: migrate to use schema version instead of maven plugin version
+    public async getLatestTemplateVersion(context: IActionContext): Promise<string> {
+        if (!JavaTemplateProvider.latestVersion) {
+            const response: HttpOperationResponse = await requestUtils.sendRequestWithExtTimeout(context, { method: 'GET', url: repositoryUrl });
+            const metadate: string = nonNullProp(response, 'bodyAsText');
+            const match: RegExpMatchArray | null = metadate.match(/<release>(.*)<\/release>/i);
+            if (!match) {
+                throw new Error(localize('failedToDetectPluginVersion', 'Failed to detect Azure Functions maven plugin version from maven repository.'));
+            } else {
+                JavaTemplateProvider.latestVersion = match[1].trim();
+            }
         }
+        return JavaTemplateProvider.latestVersion;
     }
 
     public async getLatestTemplates(context: IActionContext): Promise<ITemplates> {
-        await mavenUtils.validateMavenInstalled(context);
-
-        const projectPath: string = this.getProjectPath();
-        const commandResult: string = await mavenUtils.executeMvnCommand(context.telemetry.properties, undefined, projectPath, 'azure-functions:list');
-        const regExp: RegExp = />> templates begin <<([\S\s]+)^.+INFO.+ >> templates end <<$[\S\s]+>> bindings begin <<([\S\s]+)^.+INFO.+ >> bindings end <<$[\S\s]+>> resources begin <<([\S\s]+)^.+INFO.+ >> resources end <<$/gm;
-        const regExpResult: RegExpExecArray | null = regExp.exec(commandResult);
-        if (regExpResult && regExpResult.length > 3) {
-            this._rawTemplates = parseJson<IRawJavaTemplates>(regExpResult[1]).templates;
-            this._rawBindings = parseJson(regExpResult[2]);
-            this._rawResources = parseJson(regExpResult[3]);
-            return parseScriptTemplates(this._rawResources, this._rawTemplates, this._rawBindings);
-        } else {
-            throw new Error(localize('oldFunctionPlugin', 'You must update the Azure Functions maven plugin for this functionality.'));
-        }
+        this._rawTemplates = (await feedUtils.getJsonFeed<IRawJavaTemplates>(context, templatesUrl)).templates;
+        this._rawBindings = await feedUtils.getJsonFeed(context, bindingsUrl);
+        this._rawResources = await feedUtils.getJsonFeed(context, resourcesUrl);
+        return parseScriptTemplates(this._rawResources, this._rawTemplates, this._rawBindings);
     }
 
     /**
@@ -70,13 +69,5 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
     // eslint-disable-next-line @typescript-eslint/require-await
     protected async getCacheKeySuffix(): Promise<string> {
         return 'Java';
-    }
-
-    private getProjectPath(): string {
-        if (!this.projectPath) {
-            throw new Error(localize('projectMustBeOpen', 'You must have a project open to list Java templates.'));
-        } else {
-            return this.projectPath;
-        }
     }
 }


### PR DESCRIPTION
### Issues to resolve
Currently we use functions maven plugin to get java function templates and generate new function, which has a hard dependency for maven plugin and could not work for java projects with other build tools like gradle. 
Besides, create new function with maven may have poor performance as maven goal may take much time to initialization.

### Solution
- Create Java Function class by ts directly instead of invoke `mvn functions:add`
- Refactor java template provider to get latest template from remote resource

### Next steps
In this PR I still use the version of functions maven plugin as the template version to keep compatibility with history data, we may need set the version for template in the future.
